### PR TITLE
implemented wrappers around some tree sitter functions CU-86bxxyctr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "csharp-tree-sitter-utils-rs"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tree-sitter = "0.17.1"
+tree-sitter-c-sharp = "0.16"
+
+[dev-dependencies]
+colored = "2.1.0"
+regex = "1.10.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ mod with_source;
 use crate::with_source::WithSource;
 pub mod node_extensions;
 pub mod tree_cursor_extensions;
+pub mod tree_extensions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+mod with_source;
+use crate::with_source::WithSource;
+pub mod node_extensions;
+pub mod tree_cursor_extensions;

--- a/src/node_extensions/extended_node.rs
+++ b/src/node_extensions/extended_node.rs
@@ -1,0 +1,32 @@
+use std::rc::Rc;
+
+use tree_sitter::Node;
+
+use super::NodeExtensions;
+use crate::WithSource;
+
+pub struct ExtendedNode<'t, 's> {
+    pub ts_node: Node<'t>,
+    source: Rc<&'s str>,
+}
+
+impl<'t, 's> ExtendedNode<'t, 's> {
+    pub fn new(node: Node<'t>, source: Rc<&'s str>) -> Self {
+        ExtendedNode {
+            ts_node: node,
+            source,
+        }
+    }
+}
+
+impl<'t, 's> WithSource<'s> for ExtendedNode<'t, 's> {
+    fn get_complete_source(self: &Self) -> Rc<&'s str> {
+        self.source.clone()
+    }
+}
+
+impl<'t, 's> NodeExtensions<'s> for ExtendedNode<'t, 's> {
+    fn get_source(self: &Self) -> String {
+        self.source[self.ts_node.start_byte()..self.ts_node.end_byte()].to_string()
+    }
+}

--- a/src/node_extensions/extended_node.rs
+++ b/src/node_extensions/extended_node.rs
@@ -5,13 +5,13 @@ use tree_sitter::Node;
 use super::NodeExtensions;
 use crate::WithSource;
 
-pub struct ExtendedNode<'t, 's> {
+pub struct ExtendedNode<'t> {
     pub ts_node: Node<'t>,
-    source: Rc<&'s str>,
+    source: Rc<String>,
 }
 
-impl<'t, 's> ExtendedNode<'t, 's> {
-    pub fn new(node: Node<'t>, source: Rc<&'s str>) -> Self {
+impl<'t> ExtendedNode<'t> {
+    pub fn new(node: Node<'t>, source: Rc<String>) -> Self {
         ExtendedNode {
             ts_node: node,
             source,
@@ -19,13 +19,13 @@ impl<'t, 's> ExtendedNode<'t, 's> {
     }
 }
 
-impl<'t, 's> WithSource<'s> for ExtendedNode<'t, 's> {
-    fn get_complete_source(self: &Self) -> Rc<&'s str> {
+impl<'t> WithSource for ExtendedNode<'t> {
+    fn get_complete_source(self: &Self) -> Rc<String> {
         self.source.clone()
     }
 }
 
-impl<'t, 's> NodeExtensions<'s> for ExtendedNode<'t, 's> {
+impl<'t> NodeExtensions for ExtendedNode<'t> {
     fn get_source(self: &Self) -> String {
         self.source[self.ts_node.start_byte()..self.ts_node.end_byte()].to_string()
     }

--- a/src/node_extensions/mod.rs
+++ b/src/node_extensions/mod.rs
@@ -1,0 +1,5 @@
+pub mod extended_node;
+pub mod node_extensions;
+
+pub use extended_node::ExtendedNode;
+pub use node_extensions::NodeExtensions;

--- a/src/node_extensions/node_extensions.rs
+++ b/src/node_extensions/node_extensions.rs
@@ -1,3 +1,3 @@
-pub trait NodeExtensions<'s> {
+pub trait NodeExtensions {
     fn get_source(self: &Self) -> String;
 }

--- a/src/node_extensions/node_extensions.rs
+++ b/src/node_extensions/node_extensions.rs
@@ -1,0 +1,3 @@
+pub trait NodeExtensions<'s> {
+    fn get_source(self: &Self) -> String;
+}

--- a/src/tree_cursor_extensions/extended_tree_cursor.rs
+++ b/src/tree_cursor_extensions/extended_tree_cursor.rs
@@ -4,13 +4,13 @@ use tree_sitter::TreeCursor;
 
 use crate::{node_extensions::ExtendedNode, with_source::WithSource};
 
-pub struct ExtendedTreeCursor<'t, 's> {
+pub struct ExtendedTreeCursor<'t> {
     cursor: TreeCursor<'t>,
-    source: Rc<&'s str>,
+    source: Rc<String>,
 }
 
-impl<'t, 's> ExtendedTreeCursor<'t, 's> {
-    pub fn new(cursor: TreeCursor<'t>, source: &Rc<&'s str>) -> Self {
+impl<'t> ExtendedTreeCursor<'t> {
+    pub fn new(cursor: TreeCursor<'t>, source: &Rc<String>) -> Self {
         ExtendedTreeCursor {
             cursor,
             source: source.clone(),
@@ -18,14 +18,14 @@ impl<'t, 's> ExtendedTreeCursor<'t, 's> {
     }
 }
 
-impl<'t, 's> WithSource<'s> for ExtendedTreeCursor<'t, 's> {
-    fn get_complete_source(self: &Self) -> Rc<&'s str> {
+impl<'t> WithSource for ExtendedTreeCursor<'t> {
+    fn get_complete_source(self: &Self) -> Rc<String> {
         self.source.clone()
     }
 }
 
-impl<'t, 's> Iterator for ExtendedTreeCursor<'t, 's> {
-    type Item = ExtendedNode<'t, 's>;
+impl<'t> Iterator for ExtendedTreeCursor<'t> {
+    type Item = ExtendedNode<'t>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let node = ExtendedNode::new(self.cursor.node(), self.source.clone());
@@ -91,7 +91,7 @@ mod tests {
 
         let cursor = root_node.walk();
 
-        let it = ExtendedTreeCursor::new(cursor, &Rc::new(code));
+        let it = ExtendedTreeCursor::new(cursor, &Rc::new(code.to_string()));
 
         let nodes = it.collect::<Vec<ExtendedNode>>();
 
@@ -154,7 +154,7 @@ mod tests {
 
         let cursor = root_node.walk();
 
-        let it = ExtendedTreeCursor::new(cursor, &Rc::new(code));
+        let it = ExtendedTreeCursor::new(cursor, &Rc::new(code.to_string()));
 
         let nodes = it.collect::<Vec<ExtendedNode>>();
 

--- a/src/tree_cursor_extensions/extended_tree_cursor.rs
+++ b/src/tree_cursor_extensions/extended_tree_cursor.rs
@@ -1,0 +1,216 @@
+use std::rc::Rc;
+
+use tree_sitter::TreeCursor;
+
+use crate::{node_extensions::ExtendedNode, with_source::WithSource};
+
+pub struct ExtendedTreeCursor<'t, 's> {
+    cursor: TreeCursor<'t>,
+    source: Rc<&'s str>,
+}
+
+impl<'t, 's> ExtendedTreeCursor<'t, 's> {
+    pub fn new(cursor: TreeCursor<'t>, source: &Rc<&'s str>) -> Self {
+        ExtendedTreeCursor {
+            cursor,
+            source: source.clone(),
+        }
+    }
+}
+
+impl<'t, 's> WithSource<'s> for ExtendedTreeCursor<'t, 's> {
+    fn get_complete_source(self: &Self) -> Rc<&'s str> {
+        self.source.clone()
+    }
+}
+
+impl<'t, 's> Iterator for ExtendedTreeCursor<'t, 's> {
+    type Item = ExtendedNode<'t, 's>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let node = ExtendedNode::new(self.cursor.node(), self.source.clone());
+
+        if !self.cursor.goto_first_child() {
+            if !self.cursor.goto_next_sibling() {
+                loop {
+                    if !self.cursor.goto_next_sibling() {
+                        if !self.cursor.goto_parent() {
+                            return None;
+                        }
+                    } else {
+                        return self.next();
+                    }
+                }
+            }
+        }
+
+        Some(node)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
+
+    use crate::node_extensions::node_extensions::NodeExtensions;
+    use crate::node_extensions::ExtendedNode;
+
+    use super::ExtendedTreeCursor;
+    use colored::Colorize;
+    use regex::Regex;
+
+    use tree_sitter::Parser;
+
+    #[test]
+    fn should_return_expected_elements() {
+        let mut parser = get_parser();
+
+        let code = r#"
+        using System;
+
+        namespace HelloWorld
+        {
+            [ClassAttribute("AttributeValue")]
+            class Program
+            {
+                [MethodAttribute("MethodAttributeValue1", "MethodAttributeValue2")]
+                public Task Run() {}
+
+                static void Main(string[] args)
+                {
+                    Console.WriteLine("Hello, World!");
+                    // this is a comment
+                }
+            }
+        }
+        "#;
+
+        let tree = parser.parse(code, None).unwrap();
+
+        let root_node = tree.root_node();
+
+        let cursor = root_node.walk();
+
+        let it = ExtendedTreeCursor::new(cursor, &Rc::new(code));
+
+        let nodes = it.collect::<Vec<ExtendedNode>>();
+
+        contains_node_with_kind_and_text_regex("using_directive", "using System;", &nodes);
+
+        contains_node_with_kind_and_text_regex(
+            "namespace_declaration",
+            "namespace HelloWorld",
+            &nodes,
+        );
+
+        contains_node_with_kind_and_text_regex(
+            "attribute",
+            &regex::escape(r#"ClassAttribute("AttributeValue")"#),
+            &nodes,
+        );
+
+        contains_node_with_kind_and_text_regex("class_declaration", "class Program", &nodes);
+
+        contains_node_with_kind_and_text_regex(
+            "attribute",
+            &regex::escape(r#"MethodAttribute("MethodAttributeValue1", "MethodAttributeValue2")"#),
+            &nodes,
+        );
+
+        contains_node_with_kind_and_text_regex(
+            "method_declaration",
+            &regex::escape(r#"public Task Run() {}"#),
+            &nodes,
+        );
+
+        contains_node_with_kind_and_text_regex(
+            "method_declaration",
+            &regex::escape(r#"static void Main(string[] args)"#),
+            &nodes,
+        );
+
+        contains_node_with_kind_and_text_regex(
+            "expression_statement",
+            &regex::escape(r#"Console.WriteLine("Hello, World!");"#),
+            &nodes,
+        );
+
+        contains_node_with_kind_and_text_regex(
+            "comment",
+            &regex::escape(r#" this is a comment"#),
+            &nodes,
+        );
+    }
+
+    #[test]
+    fn should_be_well_behaved_for_empty_input() {
+        let mut parser = get_parser();
+
+        let code = "";
+
+        let tree = parser.parse(code, None).unwrap();
+
+        let root_node = tree.root_node();
+
+        let cursor = root_node.walk();
+
+        let it = ExtendedTreeCursor::new(cursor, &Rc::new(code));
+
+        let nodes = it.collect::<Vec<ExtendedNode>>();
+
+        assert!(nodes.is_empty());
+    }
+
+    fn contains_node_with_kind_and_text_regex(kind: &str, regex: &str, nodes: &Vec<ExtendedNode>) {
+        let regex = Regex::new(regex).unwrap();
+
+        let contains = nodes
+            .iter()
+            .any(|n| n.ts_node.kind() == kind && regex.is_match(&n.get_source()));
+
+        if !contains {
+            let candidates: Vec<String> = nodes
+                .iter()
+                .filter(|n| n.ts_node.kind() == kind)
+                .map(|n| n.get_source())
+                .collect();
+
+            let kind = kind.to_string().yellow();
+            let regex = regex.to_string().yellow();
+
+            let candidates_help: String = match candidates.len() {
+                0 => format!(
+                    "Found {} nodes of the kind {kind} in the entire input! Perhaps specify a different kind then {kind}?",
+                    "no".red()
+                ),
+                1 => format!(
+                    "Found {} node of same kind with text: \n---\n{}\n---\nPerhaps you meant that one?",
+                    "one".yellow(),
+                    candidates[0].to_string().yellow()
+                ),
+                _ => format!(
+                    "Found {} nodes of same kind with texts: [\n---\n{}\n---\n].Perhaps you meant one of those?",
+                    candidates.len().to_string().yellow(),
+                    candidates
+                        .iter()
+                        .map(|c| c.yellow().to_string())
+                        .collect::<Vec<String>>()
+                        .join("\n---\n---\n")
+                ),
+            };
+
+            panic!(
+                "Expected to find tree sitter node of kind {kind} and text matching regex {regex} but none was found.\nhelp: {candidates_help}\n",
+            );
+        }
+    }
+
+    fn get_parser() -> Parser {
+        let mut parser = Parser::new();
+        parser
+            .set_language(tree_sitter_c_sharp::language())
+            .unwrap();
+
+        parser
+    }
+}

--- a/src/tree_cursor_extensions/mod.rs
+++ b/src/tree_cursor_extensions/mod.rs
@@ -1,0 +1,2 @@
+pub mod extended_tree_cursor;
+pub use extended_tree_cursor::ExtendedTreeCursor;

--- a/src/tree_extensions/extended_tree.rs
+++ b/src/tree_extensions/extended_tree.rs
@@ -1,0 +1,90 @@
+use std::rc::Rc;
+
+use tree_sitter::{Parser, Tree};
+
+use crate::{
+    node_extensions::ExtendedNode, tree_cursor_extensions::ExtendedTreeCursor,
+    with_source::WithSource,
+};
+
+pub struct ExtendedTree<'s> {
+    pub ts_tree: Tree,
+    source: Rc<&'s str>,
+}
+
+impl<'s> WithSource<'s> for ExtendedTree<'s> {
+    fn get_complete_source(self: &Self) -> Rc<&'s str> {
+        self.source.clone()
+    }
+}
+
+impl<'s> ExtendedTree<'s> {
+    fn new(source: &Rc<&'s str>) -> Self {
+        let mut parser = Parser::new();
+        parser
+            .set_language(tree_sitter_c_sharp::language())
+            .unwrap();
+
+        let tree = parser.parse(source.as_bytes(), None).unwrap();
+
+        ExtendedTree {
+            ts_tree: tree,
+            source: source.clone(),
+        }
+    }
+}
+
+impl<'t, 's> IntoIterator for &'t ExtendedTree<'s>
+where
+    's: 't,
+{
+    type Item = ExtendedNode<'t, 's>;
+    type IntoIter = ExtendedTreeCursor<'t, 's>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ExtendedTreeCursor::new(
+            self.ts_tree.root_node().walk(),
+            &self.get_complete_source().clone(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::node_extensions::NodeExtensions;
+    use std::rc::Rc;
+
+    use super::ExtendedTree;
+
+    #[test]
+    fn should_return_expected_elements() {
+        let code = r#"
+        using System;
+
+        namespace HelloWorld
+        {
+            [ClassAttribute("AttributeValue")]
+            class Program
+            {
+                [MethodAttribute("MethodAttributeValue1", "MethodAttributeValue2")]
+                public Task Run() {}
+
+                static void Main(string[] args)
+                {
+                    Console.WriteLine("Hello, World!");
+                    // this is a comment
+                }
+            }
+        }
+        "#;
+
+        let tree = ExtendedTree::new(&Rc::new(code));
+
+        let mut it = tree.into_iter();
+
+        it.find(|n| {
+            n.ts_node.kind() == "class_declaration" && n.get_source().contains("class Program")
+        })
+        .unwrap();
+    }
+}

--- a/src/tree_extensions/extended_tree.rs
+++ b/src/tree_extensions/extended_tree.rs
@@ -7,19 +7,19 @@ use crate::{
     with_source::WithSource,
 };
 
-pub struct ExtendedTree<'s> {
+pub struct ExtendedTree {
     pub ts_tree: Tree,
-    source: Rc<&'s str>,
+    source: Rc<String>,
 }
 
-impl<'s> WithSource<'s> for ExtendedTree<'s> {
-    fn get_complete_source(self: &Self) -> Rc<&'s str> {
+impl WithSource for ExtendedTree {
+    fn get_complete_source(self: &Self) -> Rc<String> {
         self.source.clone()
     }
 }
 
-impl<'s> ExtendedTree<'s> {
-    fn new(source: &Rc<&'s str>) -> Self {
+impl ExtendedTree {
+    fn new(source: &Rc<String>) -> Self {
         let mut parser = Parser::new();
         parser
             .set_language(tree_sitter_c_sharp::language())
@@ -34,12 +34,9 @@ impl<'s> ExtendedTree<'s> {
     }
 }
 
-impl<'t, 's> IntoIterator for &'t ExtendedTree<'s>
-where
-    's: 't,
-{
-    type Item = ExtendedNode<'t, 's>;
-    type IntoIter = ExtendedTreeCursor<'t, 's>;
+impl<'t> IntoIterator for &'t ExtendedTree {
+    type Item = ExtendedNode<'t>;
+    type IntoIter = ExtendedTreeCursor<'t>;
 
     fn into_iter(self) -> Self::IntoIter {
         ExtendedTreeCursor::new(
@@ -78,7 +75,7 @@ mod tests {
         }
         "#;
 
-        let tree = ExtendedTree::new(&Rc::new(code));
+        let tree = ExtendedTree::new(&Rc::new(code.to_string()));
 
         let mut it = tree.into_iter();
 

--- a/src/tree_extensions/mod.rs
+++ b/src/tree_extensions/mod.rs
@@ -1,0 +1,2 @@
+pub mod extended_tree;
+pub use extended_tree::ExtendedTree;

--- a/src/with_source.rs
+++ b/src/with_source.rs
@@ -1,5 +1,5 @@
 use std::rc::Rc;
 
-pub trait WithSource<'s> {
-    fn get_complete_source(self: &Self) -> Rc<&'s str>;
+pub trait WithSource {
+    fn get_complete_source(self: &Self) -> Rc<String>;
 }

--- a/src/with_source.rs
+++ b/src/with_source.rs
@@ -1,0 +1,5 @@
+use std::rc::Rc;
+
+pub trait WithSource<'s> {
+    fn get_complete_source(self: &Self) -> Rc<&'s str>;
+}


### PR DESCRIPTION
- implemented iterable wrapper for tree cursor (closes #1)
  - this allows for easier tree sitter `Tree` traversal
- [x] implement tree wrapper
  - [x] into iterator 